### PR TITLE
Specifiy minimum node version at 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   },
   "dependencies": {
     "marked": "^0.3.6",
-    "node": "0.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-scripts": "^1.0.7",
     "standard": "^10.0.2"
+  },
+  "engines" : {
+    "node" : ">=6.0.0"
   }
 }


### PR DESCRIPTION
Note that no error is thrown unless user has
npm configured to throw one https://docs.npmjs.com/misc/config#engine-strict

Adding this here will at least help savvy users see the required node version.
I used 6.0.0 because is what react-scripts requires.