### PR TITLE
Fixes id="{props.name}" in rendered html.

### DIFF
--- a/lessons/display.md
+++ b/lessons/display.md
@@ -163,6 +163,7 @@ FIXME-18: diagram
 ## Creating Components
 
 - If we're defining functions, we can write new ones
+- Component names must start with a capital letter to differentiate them from regular tags.
 
 ```html
   <body>

--- a/src/display/pass-parameters.html
+++ b/src/display/pass-parameters.html
@@ -15,7 +15,7 @@
       const allNames = ['McNulty', 'Jennings', 'Snyder', 'Meltzer', 'Bilas', 'Lichterman']
 
       const ListElement = (props) => {
-        return (<li id="{props.name}"><em>{props.name}</em></li>)
+        return (<li id={props.name}><em>{props.name}</em></li>)
       }
 
       ReactDOM.render(


### PR DESCRIPTION
The output html did not have the name mapped to the id attribute. All have `id="{props.name}"`. Unquoting seems to fix. Babel magic inserts the quotes around the string in the output.